### PR TITLE
tuning a css style . margin left 30px ,not 80px

### DIFF
--- a/css/material-kit.css
+++ b/css/material-kit.css
@@ -3554,7 +3554,7 @@ input[type="file"] > input[type="button"]::-moz-focus-inner {
 }
 
 .main-raised {
-  margin: -300px 80px 20px;
+  margin: -300px 30px 20px 30px;
   border-radius: 6px;
   box-shadow: 0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
When margin left set to 80px, there are not enough space to display the sections content, like **projects**

**MacBook Pro (Retina, 13-inch)** come up with this problem , also **iPad Pro**.

